### PR TITLE
Version Bump to 0.0.3

### DIFF
--- a/src/joule.janet
+++ b/src/joule.janet
@@ -518,14 +518,20 @@
 (def clear-clipboard []
   (edset :clipboard @[]))
 
-(defn clip-copy-single [kind]
-  (let [[from-x from-y] (values (editor-state :select-from))
-        [to-x to-y] (values (editor-state :select-to))]
-    ))
+(defn clip-copy-single [kind y from-x to-x]
+  )
 
 (defn clip-copy-multi [kind]
   (let [[from-x from-y] (values (editor-state :select-from))
         [to-x to-y] (values (editor-state :select-to))]
+    # Copy first line-- might be partial
+    (clip-copy-single kind from-y from-x (max-x from-y))
+    
+    # Copy intermediate lines 
+
+
+    # Copy last line-- might be partial
+    (clip-copy-single kind from-y from-x (max-x to-y))
     ))
 
 # Kind can be :copy or :cut

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -853,19 +853,21 @@
     (move-to-match)) 
 
   (let [key (read-key)
-        exit-search |(do (return-to-temp-pos)
-                         (clear-temp-pos)
-                         (editor-refresh-screen))]
+        exit-search |(do (clear-temp-pos)
+                         (edset :search-active nil))
+        cancel-search |(do (return-to-temp-pos)
+                           (exit-search)
+                           (editor-refresh-screen))]
     (case (get keymap key key)
-      (ctrl-key (chr "q")) (exit-search)
+      (ctrl-key (chr "q")) (cancel-search)
       (ctrl-key (chr "d")) (enter-debugger)
 
       :enter (do (move-to-match)
                  (find-next))
-      :esc (exit-search)
+      :esc (cancel-search)
       
       # Otherwise
-      (do (clear-temp-pos)
+      (do (exit-search)
           # Process keypress normally
           (editor-process-keypress key)))))
 
@@ -888,6 +890,8 @@
                                         (find-next true)
                                         (do (return-to-temp-pos)
                                             (clear-temp-pos)
+                                            (set modal-rethome false)
+                                            (edset :search-active nil)
                                             (send-status-msg "No matches found."))))))
 
 ### Init and main ###

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -575,6 +575,7 @@
       (clear-selection)
       (edset :cx from-x))))
 
+# TODO: Debug this-- almost definitely glitchy
 (defn clip-copy-multi [kind]
   (let [[from-x from-y] (values (editor-state :select-from))
         [to-x to-y] (values (editor-state :select-to))]

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -240,14 +240,29 @@
       (move-viewport :home))
     (edset :cx (max-x (abs-y)))))
 
+(def delim
+  ~{:delim (+ " " ";" ":")
+    :main :delim})
+
+(defn seek-delim [] 
+  )
+
+(defn next-word [dir]
+  )
+
+(defn prev-word []
+  )
+
 (defn move-cursor [direction]
-  (case direction 
+  (case di7rection 
     :up (edup :cy dec)
     :down (edup :cy inc)
     :left (edup :cx dec)
     :right (edup :cx inc)
     :home (move-cursor-home)
-    :end (move-cursor-end)))
+    :end (move-cursor-end)
+    :word-left (prev-word)
+    :word-right (next-word)))
 
 (defn editor-scroll []
   (let [cx (editor-state :cx)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -244,17 +244,25 @@
   ~{:delim (+ " " ";" ":")
     :main :delim})
 
-(defn seek-delim [] 
-  )
+(defn seek-delim []) 
+  
+(varfn wrap-to-end-of-prev-line [])
+(varfn wrap-to-start-of-next-line [])
 
-(defn next-word [dir]
-  )
+(defn next-word []
+  (let [line (get-in editor-state [:erows (abs-y)])
+        s (string/slice line (abs-x))
+        ls (safe-len (take-while |(= $ 32) (string/bytes s)))]
+    (if (= s "")
+      (do (wrap-to-start-of-next-line)
+          (next-word))
+      (edup :cx |(+ $ (string/find " " s ls))))))
 
 (defn prev-word []
   )
 
 (defn move-cursor [direction]
-  (case di7rection 
+  (case direction 
     :up (edup :cy dec)
     :down (edup :cy inc)
     :left (edup :cx dec)
@@ -304,11 +312,11 @@
   (when (> cx (editor-state :rememberx))
     (edset :rememberx cx)))
 
-(defn wrap-to-end-of-prev-line []
+(varfn wrap-to-end-of-prev-line []
   (move-cursor :up)
   (move-cursor :end))
 
-(defn wrap-to-start-of-next-line []
+(varfn wrap-to-start-of-next-line []
   (move-cursor :down)
   (move-cursor :home))
 
@@ -627,7 +635,7 @@
       
       # TODO: Ctrl + arrows
       :ctrlleftarrow (break)
-      :ctrlrightarrow (break)
+      :ctrlrightarrow (move-cursor :word-right)
       :ctrluparrow (break)
       :ctrldownarrow (break)
       

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -246,14 +246,15 @@
 
 (defn move-word [dir] 
   (if (and (= dir :left) (= (editor-state :cx) 0) (= (editor-state :cy) 0)) (break))
-  (let [left (case dir :left true :right false)
+  (let [delims " .-_([{}])'\"\\/"
+        left (case dir :left true :right false)
         [f df] (if left [string/reverse -] [identity +])
         mf (if left wrap-to-end-of-prev-line wrap-to-start-of-next-line)
         line (f (get-in editor-state [:erows (abs-y)]))
         x (if left (- (max-x (abs-y)) (abs-x)) (abs-x))
         s (string/slice line x)
-        ls (safe-len (take-while |(= $ 32) (string/bytes s)))
-        d (string/find " " s ls)]
+        ls (safe-len (take-while |(index-of $ (string/bytes delims)) (string/bytes s)))
+        d (peg/find ~(set ,delims) s ls)]
     (cond 
       (= (string/trim s) "") (do (mf)
                                  (move-word dir))
@@ -561,7 +562,7 @@
     (move-cursor :up)
     (move-cursor :end) 
     # drop line being left
-    (edup :erows |(array/remove $ leaving-y))
+    (kill-row leaving-y)
     # append current-line to new line
     (update-erow (abs-y) | (string $ current-line))))
 

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -367,19 +367,10 @@
   (peg/compile
    ~{:esc-code (replace (<- (* "\e[" (some (+ :d ";")) "m"))
                         ,(fn [cap] [cap 0]))
-     :else (replace (<- (to "\e")) 
+     :else (replace (<- (to (+ "\e" -1))) 
                     ,(fn [cap] [cap (length cap)]))
      :main (some (+ :esc-code :else))}))
 
-(comment 
-  (peg/match esc-code-peg colorful-string)
-  
-(peg/match ~(<- (to "\e")) "    \e")
-
-  (peg/match ~(<- (some 1)) "111")
-
-  (peg/match ~(<- (* "\e" (some (+ :d ";")) "m")) "\e[0m")
-  (peg/match esc-code-peg "\e[0m"))
 
 (defn hl-x [str x]
   (let [str-peg (reverse (peg/match esc-code-peg str))] 
@@ -681,11 +672,6 @@
                :select-to @{:x (abs-x) :y (abs-y)})
         (grow-selection dir))))
 
-(comment 
-  (reset-editor-state)
-  (load-file "../LICENSE")
-  )
-
 ### Input ###
 
 (defn handle-out-of-bounds []
@@ -833,8 +819,12 @@
       :ctrldownarrow (break)
       
       # TODO: Shift + arrows
-      :shiftleftarrow (handle-selection :left)
-      :shiftrightarrow (handle-selection :right)
+      :shiftleftarrow (if (= (abs-x) 0)
+                        (break)
+                        (handle-selection :left))
+      :shiftrightarrow (if (= (abs-x) (rowlen (abs-y)))
+                        (break)
+                        (handle-selection :right))
       # TODO: Handling selection up and down
       :shiftuparrow (break)
       :shiftdownarrow (break)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -27,7 +27,8 @@
    1013 :shiftleftarrow
    1014 :shiftrightarrow
    1015 :shiftuparrow
-   1016 :shiftdownarrow})
+   1016 :shiftdownarrow
+   1017 :shiftdel})
 
 ### Data ###
 
@@ -546,6 +547,14 @@
     (move-cursor :left))
   (update-erow (abs-y) | (string/cut $ (abs-x))))
 
+(defn kill-row [y]
+  (edup :erows |(array/remove $ y)))
+
+(defn delete-row []
+  (kill-row (abs-y))
+  (move-cursor :home)
+  (edup :dirty inc))
+
 (defn backspace-back-to-prev-line []
   (let [current-line (get-in editor-state [:erows (abs-y)])
         leaving-y (abs-y)]
@@ -642,6 +651,8 @@
       :shiftrightarrow (break)
       :shiftuparrow (break)
       :shiftdownarrow (break)
+
+      :shiftdel (delete-row)
       
       :enter (carriage-return)
 
@@ -777,6 +788,8 @@
       :shiftrightarrow (break)
       :shiftuparrow (break)
       :shiftdownarrow (break)
+
+      :shiftdel (break)
 
       :home (move-cursor-modal :home)
       :end (move-cursor-modal :end)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -55,6 +55,9 @@
             :statusmsgtime 0
             :modalmsg ""
             :modalinput ""
+            :select-from @{:x 0 :y 0}
+            :select-to @{:x 0 :y 0}
+            :clipboard @["Hello, there"]
             :screenrows (- ((get-window-size) :rows) 2)
             :screencols ((get-window-size) :cols)
             :userconfig @{:scrollpadding 5
@@ -510,6 +513,31 @@
 
   (file/write stdout abuf)
   (file/flush stdout))
+### Clipboard ###5
+
+(def clear-clipboard []
+  (edset :clipboard @[]))
+
+(defn clip-copy-single [kind]
+  (let [[from-x from-y] (values (editor-state :select-from))
+        [to-x to-y] (values (editor-state :select-to))]
+    ))
+
+(defn clip-copy-multi [kind]
+  (let [[from-x from-y] (values (editor-state :select-from))
+        [to-x to-y] (values (editor-state :select-to))]
+    ))
+
+# Kind can be :copy or :cut
+(defn copy-to-clipboard [kind]
+  (clear-clipboard)
+  (if (= ((editor-state :select-from) :y) 
+         ((editor-state :select-to) :y))
+    (clip-copy-single kind)
+    (clip-copy-multi kind)))
+
+(defn paste-clipboard []
+  (map editor-handle-typing (string/bytes (editor-state :clipboard))))
 
 ### Input ###
 
@@ -606,6 +634,10 @@
       (ctrl-key (chr "g")) (jump-to-modal)
       (ctrl-key (chr "z")) (break) # TODO: Undo in normal typing
       (ctrl-key (chr "y")) (break) # TODO: Redo in normal typing
+      
+      (ctrl-key (chr "c")) (copy-to-clipboard :copy)
+      (ctrl-key (chr "x")) (copy-to-clipboard :cut)
+      (ctrl-key (chr "v")) (paste-clipboard)
 
       # If on home page of file
       :pageup (if (= 0 v-offset)
@@ -641,9 +673,10 @@
       :downarrow (do (move-cursor-with-mem :down)
                      (update-x-memory cx))
       
-      # TODO: Ctrl + arrows
       :ctrlleftarrow (move-cursor :word-left)
       :ctrlrightarrow (move-cursor :word-right)
+      
+      # TODO: Multiple cursors?
       :ctrluparrow (break)
       :ctrldownarrow (break)
       
@@ -657,7 +690,7 @@
       
       :enter (carriage-return)
 
-      # TODO: Escape
+      # TODO: Escape-- cancel selection
       :esc (break)
 
       :backspace (cond

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -565,11 +565,15 @@
 (defn clear-clipboard []
   (edset :clipboard @[]))
 
+(varfn clear-selection [])
+
 (defn clip-copy-single [kind y from-x to-x]
   (let [line (string/slice (get-in editor-state [:erows y]) from-x to-x)]
     (edup :clipboard |(array/push $ line))
     (when (= kind :cut)
-      (update-erow y |(string/cut $ from-x to-x)))))
+      (update-erow y | (string/cut $ from-x (dec to-x)))
+      (clear-selection)
+      (edset :cx from-x))))
 
 (defn clip-copy-multi [kind]
   (let [[from-x from-y] (values (editor-state :select-from))
@@ -619,7 +623,7 @@
   (and (not (empty? (editor-state :select-from)))
        (not (empty? (editor-state :select-to)))))
 
-(defn clear-selection []
+(varfn clear-selection []
   (edset :select-from {}
          :select-to {}))
 


### PR DESCRIPTION
New Features
- Shift + Del to delete an entire row
- Select text with Shift + Arrows (same line only for now)
- Jump to row number (Ctrl + G)
- Navigate by word with Ctrl + Arrows
- Basic Clipboard functionality and Copy (Ctrl + C) / Cut (Ctrl + X) / Paste (Ctrl + P)

Bug Fixes
- Glitches when exiting modals and return to cursor position
- Bugs in confirm-lose-changes modal