### PR TITLE
Bugfixes to 0.0.4-a

### DIFF
--- a/src/jermbox.janet
+++ b/src/jermbox.janet
@@ -1,4 +1,5 @@
 (import jermbox)
+(use /src/utilities)
 
 (defn init-jermbox []
   (setdyn :ev (jermbox/init-event))
@@ -55,13 +56,15 @@
    :modifier (jermbox/event-modifier event)
    :character (jermbox/event-character event)
    :x (jermbox/event-x event)
-   :y (jermbox/event-y event)})
+   :y (jermbox/event-y event)
+   :width (jermbox/event-width event)
+   :height (jermbox/event-height event)})
 
 (defn main-loop [event]
   (var keystrokes @[]) 
   (jermbox/poll-event event)
   (array/push keystrokes (get-key-struct event))
-  (when (deep= keystrokes @[{:character 0 :key 27 :modifier 0 :x 0 :y 0}])
+  (when (deep= keystrokes @[{:character 0 :key 27 :modifier 0 :x 0 :y 0 :width 0 :height 0}])
     (while (jermbox/peek-event event 10)
       (array/push keystrokes (get-key-struct event))))
   keystrokes)
@@ -70,9 +73,12 @@
   (let [{:key key
          :character char
          :x x
-         :y y} ar]
-    (if (= key 65513)
-      [:mouseleft x y]
+         :y y
+         :width width
+         :height height} ar]
+    (cond 
+      (= key 65513) [:mouseleft x y]
+      (or (not= 0 width) (not= 0 height)) :windowresize
       (let [value (if (= 0 key) char key)] 
         (get keymap value value)))))
 
@@ -97,6 +103,7 @@
 
 (defn read-key [event]
   (let [jermbox-array (main-loop event)] 
+    (log jermbox-array)
     (if (= 1 (length jermbox-array))
       (convert-single (first jermbox-array))
       (convert-multiple jermbox-array))))

--- a/src/jermbox.janet
+++ b/src/jermbox.janet
@@ -103,7 +103,7 @@
 
 (defn read-key [event]
   (let [jermbox-array (main-loop event)] 
-    (log jermbox-array)
+    # (log jermbox-array)
     (if (= 1 (length jermbox-array))
       (convert-single (first jermbox-array))
       (convert-multiple jermbox-array))))

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -686,8 +686,8 @@
           :ctrl-w (close-file :close)
           :ctrl-f (find-in-text-modal)
           :ctrl-g (jump-to-modal)
-          :ctrl-z (break) # TODO: Undo in normal typing
-          :ctrl-y (break) # TODO: Redo in normal typing
+          # :ctrl-z (break) # TODO: Undo in normal typing
+          # :ctrl-y (break) # TODO: Redo in normal typing
           
           :ctrl-c (copy-to-clipboard :copy)
           :ctrl-x (copy-to-clipboard :cut)
@@ -736,8 +736,8 @@
           :ctrlrightarrow (move-cursor :word-right)
           
           # TODO: Multiple cursors?
-          :ctrluparrow (break)
-          :ctrldownarrow (break)
+          # :ctrluparrow (break)
+          # :ctrldownarrow (break)
           
           :shiftleftarrow (if (= (abs-x) 0)
                             (break)
@@ -747,14 +747,14 @@
                             (handle-selection :right))
           
           # TODO: Shift + Ctrl + Arrows
-          :ctrlshiftuparrow (break)
-          :ctrlshiftdownarrow (break)
-          :ctrlshiftrightarrow (break)
-          :ctrlshiftleftarrow (break)
+          # :ctrlshiftuparrow (break)
+          # :ctrlshiftdownarrow (break)
+          # :ctrlshiftrightarrow (break)
+          # :ctrlshiftleftarrow (break)
     
           # TODO: Handling selection up and down
-          :shiftuparrow (break)
-          :shiftdownarrow (break)
+          # :shiftuparrow (break)
+          # :shiftdownarrow (break)
     
           :shiftdel (delete-row)
           
@@ -784,10 +784,10 @@
                  (delete-char :delete))
     
           # TODO: Process mouse clicks 
-          :mouseleft (break)
-          :mouseright (break)
-          :mousemiddle (break)
-          :mouserelease (break)
+          # :mouseleft (break)
+          # :mouseright (break)
+          # :mousemiddle (break)
+          # :mouserelease (break)
 
           :mousewheelup (unless (= 0 (editor-state :rowoffset)) 
                                 (edup :rowoffset dec) 
@@ -796,7 +796,9 @@
           :mousewheeldown (do (edup :rowoffset inc)
                               (move-cursor-with-mem :in-place)
                               (update-x-memory cx))
-    
+          
+          # :windowresize (break)
+
           # TODO: Function row
     
           # Default 

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -703,8 +703,10 @@
                     (move-viewport :pageup))
           :pagedown (move-viewport :pagedown)
     
-          :home (move-cursor :home)
-          :end (move-cursor :end)
+          :home (do (edset :rememberx 0)
+                    (move-cursor :home))
+          :end (do (edset :rememberx 0) 
+                   (move-cursor :end))
     
           # TODO: Implement smarter tab stops
           :tab (repeat 4 (editor-handle-typing 32))
@@ -734,19 +736,23 @@
                          (move-cursor-with-mem :down)
                          (update-x-memory cx))
           
-          :ctrlleftarrow (move-cursor :word-left)
-          :ctrlrightarrow (move-cursor :word-right)
+          :ctrlleftarrow (do (edset :rememberx 0) 
+                             (move-cursor :word-left))
+          :ctrlrightarrow (do (edset :rememberx 0) 
+                              (move-cursor :word-right))
           
           # TODO: Multiple cursors?
           # :ctrluparrow (break)
           # :ctrldownarrow (break)
           
-          :shiftleftarrow (if (= (abs-x) 0)
-                            (break)
-                            (handle-selection :left))
-          :shiftrightarrow (if (= (abs-x) (rowlen (abs-y)))
-                            (break)
-                            (handle-selection :right))
+          :shiftleftarrow (do (edset :rememberx 0)
+                              (if (= (abs-x) 0)
+                                (break)
+                                (handle-selection :left)))
+          :shiftrightarrow (do (edset :rememberx 0)
+                               (if (= (abs-x) (rowlen (abs-y)))
+                                 (break)
+                                 (handle-selection :right)))
           
           # TODO: Shift + Ctrl + Arrows
           # :ctrlshiftuparrow (break)
@@ -764,26 +770,28 @@
     
           :esc (when (selection-active?) (clear-selection))
     
-          :backspace (cond
-                       #On top line and home row of file; do nothing
-                       (and (= (abs-x) 0) (= (abs-y) 0)) (break)
-                       #Cursor below last file line; cursor up
-                       (> (abs-y) (dec (safe-len (editor-state :erows)))) (move-cursor :up)
-                       #Cursor at margin and viewport far left
-                       (= (abs-x) 0) (backspace-back-to-prev-line)
-                       #Otherwise
-                       (delete-char :backspace))
+          :backspace (do (edset :rememberx 0)
+                         (cond
+                           #On top line and home row of file; do nothing
+                           (and (= (abs-x) 0) (= (abs-y) 0)) (break)
+                           #Cursor below last file line; cursor up
+                           (> (abs-y) (dec (safe-len (editor-state :erows)))) (move-cursor :up)
+                           #Cursor at margin and viewport far left
+                           (= (abs-x) 0) (backspace-back-to-prev-line)
+                           #Otherwise 
+                           (delete-char :backspace)))
     
-          :delete (cond 
-                 # On last line and end of row of file; do nothing
-                 (and (= (abs-x) (rowlen (abs-y)))
-                      (= (abs-y) (dec (safe-len (editor-state :erows))))) (break)
-                 # Cursor at end of current line
-                 (= cx (- (rowlen cy) h-offset)) (delete-next-line-up) 
-                 # Cursor below last file line; cursor up
-                 (> (abs-y) (safe-len (editor-state :erows))) (break)
-                 # Otherwise
-                 (delete-char :delete))
+          :delete (do (edset :rememberx 0)
+                      (cond
+                        #On last line and end of row of file; do nothing
+                        (and (= (abs-x) (rowlen (abs-y)))
+                             (= (abs-y) (dec (safe-len (editor-state :erows))))) (break)
+                        #Cursor at end of current line
+                        (= cx (- (rowlen cy) h-offset)) (delete-next-line-up)
+                        #Cursor below last file line; cursor up
+                        (> (abs-y) (safe-len (editor-state :erows))) (break)
+                        #Otherwise
+                         (delete-char :delete)))
     
           # TODO: Process mouse clicks 
           # :mouseleft (break)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -530,8 +530,8 @@
        (not (empty? (editor-state :select-to)))))
 
 (varfn clear-selection []
-  (edset :select-from {}
-         :select-to {}))
+  (edset :select-from @{}
+         :select-to @{}))
 
 (defn grow-selection [dir]
   (let [start-x (abs-x)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -319,17 +319,19 @@
     (array/concat dup (drop (safe-len priority) secondary))))
 
 (defn add-welcome-message [rows]
-  (def messages @[(string "Joule editor -- version " version)
-                  ""
-                  "Ctrl + q                 quit"
-                  "Ctrl + l                 load"
-                  "Ctrl + s                 save"
-                  "Ctrl + a              save as"
-                  "Ctrl + f               search"
-                  "Ctrl + g       go (to line #)"
-                  "Ctrl + c                 copy"
-                  "Ctrl + p                paste"
-                  "Ctrl + n       toggle numbers"])
+  (def messages @[(string "Joule editor -- version " version)])
+  (def add-messages @[""
+                      "Ctrl + q                 quit"
+                      "Ctrl + l                 load"
+                      "Ctrl + s                 save"
+                      "Ctrl + a              save as"
+                      "Ctrl + f               search"
+                      "Ctrl + g       go (to line #)"
+                      "Ctrl + c                 copy"
+                      "Ctrl + p                paste"
+                      "Ctrl + n       toggle numbers"])
+  (if (>= (editor-state :screenrows) (+ (length messages) (length add-messages)))
+    (array/concat messages add-messages))
   (if (deep= @[] (flatten (editor-state :erows)))
     (let [r (editor-state :screenrows)
           c (editor-state :screencols)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -774,7 +774,7 @@
                        #Otherwise
                        (delete-char :backspace))
     
-          :del (cond 
+          :delete (cond 
                  # On last line and end of row of file; do nothing
                  (and (= (abs-x) (rowlen (abs-y)))
                       (= (abs-y) (dec (safe-len (editor-state :erows))))) (break)
@@ -883,7 +883,7 @@
         # BUG: This is broken when backspacing at end of current line
         :backspace (cond at-home (break)
                          (delete-char-modal :backspace))
-        :del (cond at-end (break)
+        :delete (cond at-end (break)
                    (delete-char-modal :delete))
 
         :pageup (move-cursor-modal :home)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -330,7 +330,7 @@
                       "Ctrl + c                 copy"
                       "Ctrl + p                paste"
                       "Ctrl + n       toggle numbers"])
-  (if (>= (editor-state :screenrows) (+ (length messages) (length add-messages)))
+  (if (>= (editor-state :screenrows) (+ 2 (length messages) (length add-messages)))
     (array/concat messages add-messages))
   (if (deep= @[] (flatten (editor-state :erows)))
     (let [r (editor-state :screenrows)

--- a/src/joule.janet
+++ b/src/joule.janet
@@ -164,7 +164,7 @@
         left (case dir :left true :right false)
         [f df] (if left [string/reverse -] [identity +])
         mf (if left wrap-to-end-of-prev-line wrap-to-start-of-next-line)
-        line (f (get-in editor-state [:erows (abs-y)]))
+        line (f (get-in editor-state [:erows (abs-y)] ""))
         x (if left (- (max-x (abs-y)) (abs-x)) (abs-x))
         s (string/slice line x)
         ls (safe-len (take-while |(index-of $ (string/bytes delims)) (string/bytes s)))
@@ -352,7 +352,7 @@
              (string/slice $ 0 cols) $) rows)))
 
 (defn render-tabs [rows]
-  (let [tabsize (get-in editor-state [:userconfig :tabsize])
+  (let [tabsize (get-in editor-state [:userconfig :tabsize] "")
         spaces (string/repeat " " tabsize)]
     (map |(string/replace-all "\t" spaces $) rows)))
 
@@ -395,7 +395,7 @@
   rows)
 
 (defn apply-margin [rows]
-  (let [numtype (get-in editor-state [:userconfig :numtype])]
+  (let [numtype (get-in editor-state [:userconfig :numtype] "")]
     (case numtype
       :on (add-line-numbers rows)
       :relative (add-relative-numbers rows)
@@ -472,7 +472,7 @@
 (varfn clear-selection [])
 
 (defn clip-copy-single [kind y from-x to-x]
-  (let [line (string/slice (get-in editor-state [:erows y]) from-x to-x)]
+  (let [line (string/slice (get-in editor-state [:erows y] "") from-x to-x)]
     (edup :clipboard |(array/push $ line))
     (when (= kind :cut)
       (update-erow y | (string/cut $ from-x (dec to-x)))
@@ -628,7 +628,7 @@
   (edup :dirty inc))
 
 (defn backspace-back-to-prev-line []
-  (let [current-line (get-in editor-state [:erows (abs-y)])
+  (let [current-line (get-in editor-state [:erows (abs-y)] "")
         leaving-y (abs-y)]
     (move-cursor :up)
     (move-cursor :end) 
@@ -639,7 +639,7 @@
 
 (defn delete-next-line-up []
   (unless (= (abs-y) (safe-len (editor-state :erows)))
-    (let [next-line (get-in editor-state [:erows (inc (abs-y))])]
+    (let [next-line (get-in editor-state [:erows (inc (abs-y))] "")]
       (update-erow (abs-y) |(string $ next-line))
       (edup :erows |(array/remove $ (inc (abs-y)))))))
 

--- a/src/utilities.janet
+++ b/src/utilities.janet
@@ -43,4 +43,4 @@
   (jdn/decode (slurp where)))
 
 (defn log [content]
-  (spit "log.txt" (string content "\n") :a))
+  (spit "log.txt" (string (string/format "%q" content) "\n") :a))


### PR DESCRIPTION
Bugfixes:
- Ctrl + C on program startup causes crash
- Program startup with few terminal rows causes crash
- Some keys (Home, End, PgUp, PgDn, Backspace, Delete, key combos w/ left and right arrows) don't reset x-position memory
- Delete key not working
- Resizing terminal window interpreted as space key